### PR TITLE
Support of `kill signal`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'rake'
 gem 'yard'
 gem 'safe_yaml'
 
-gem 'rspec', '>= 2.0'
+gem 'rspec', '~> 2.0'
 gem 'fakefs', '~> 0.5.0', :require => 'fakefs/safe'

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ For Procfile example given earlier the generated command will look like:
 
 `kill_timeout` option lets you override the default process kill timeout of 30 seconds.
 
+`kill_signal` option lets you override the default stopping signal, SIGTERM by default.
+
 `respawn` option controls restarting of scripts in case of their failure.
 By default this option is enabled. For
 more info look into [documentation](http://upstart.ubuntu.com/cookbook/#respawn).

--- a/lib/upstart-exporter/expanded_exporter.rb
+++ b/lib/upstart-exporter/expanded_exporter.rb
@@ -109,6 +109,10 @@ class Upstart::Exporter
       command_option(cmd_options, 'kill_timeout')
     end
 
+    def kill_signal(cmd_options)
+      command_option(cmd_options, 'kill_signal')
+    end
+
     def export_cmd_upstart_conf(cmd_name, cmd_options)
       cmd_upstart_conf_content = Templates.command(
         :app_name => app_name,
@@ -120,7 +124,8 @@ class Upstart::Exporter
         :helper_cmd_conf => helper_cmd_conf(cmd_name),
         :respawn => respawn(cmd_options),
         :respawn_limit => respawn_limit(cmd_options),
-        :kill_timeout => kill_timeout(cmd_options)
+        :kill_timeout => kill_timeout(cmd_options),
+        :kill_signal => kill_signal(cmd_options)
       )
       File.open(upstart_cmd_conf(cmd_name), 'w') do |f|
         f.write(cmd_upstart_conf_content)

--- a/lib/upstart-exporter/options/global.rb
+++ b/lib/upstart-exporter/options/global.rb
@@ -11,6 +11,7 @@ module Upstart::Exporter::Options
       'start_on_runlevel' => '[3]',
       'stop_on_runlevel' => '[3]',
       'kill_timeout' => 30,
+      'kill_signal' => 'SIGTERM',
       'respawn' => {
         'count' => 5,
         'interval' => 10

--- a/lib/upstart-exporter/templates.rb
+++ b/lib/upstart-exporter/templates.rb
@@ -53,6 +53,7 @@ stop on {{stop_on}}
 {{respawn}}
 {{respawn_limit}}
 kill timeout {{kill_timeout}}
+kill signal {{kill_signal}}
 
 script
   touch /var/log/{{app_name}}/{{cmd_name}}.log

--- a/spec/lib/upstart-exporter/errors_spec.rb
+++ b/spec/lib/upstart-exporter/errors_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require File.expand_path('../../spec_helper', File.dirname(__FILE__))
 
 describe Upstart::Exporter::Errors do
   context "when included" do

--- a/spec/lib/upstart-exporter/errors_spec.rb
+++ b/spec/lib/upstart-exporter/errors_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require_relative '../../spec_helper'
 
 describe Upstart::Exporter::Errors do
   context "when included" do

--- a/spec/lib/upstart-exporter/expanded_exporter_spec.rb
+++ b/spec/lib/upstart-exporter/expanded_exporter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require_relative '../../spec_helper'
 
 describe Upstart::Exporter::ExpandedExporter do
   before do

--- a/spec/lib/upstart-exporter/expanded_exporter_spec.rb
+++ b/spec/lib/upstart-exporter/expanded_exporter_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require File.expand_path('../../spec_helper', File.dirname(__FILE__))
 
 describe Upstart::Exporter::ExpandedExporter do
   before do

--- a/spec/lib/upstart-exporter/options/command_line_spec.rb
+++ b/spec/lib/upstart-exporter/options/command_line_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require_relative '../../../spec_helper'
 
 describe Upstart::Exporter::Options::CommandLine do
   context "when correct options are given" do

--- a/spec/lib/upstart-exporter/options/command_line_spec.rb
+++ b/spec/lib/upstart-exporter/options/command_line_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../spec_helper'
+require File.expand_path('../../../spec_helper', File.dirname(__FILE__))
 
 describe Upstart::Exporter::Options::CommandLine do
   context "when correct options are given" do

--- a/spec/lib/upstart-exporter/options/global_spec.rb
+++ b/spec/lib/upstart-exporter/options/global_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require_relative '../../../spec_helper'
 
 describe Upstart::Exporter::Options::Global do
   let(:defaults){ Upstart::Exporter::Options::Global::DEFAULTS }

--- a/spec/lib/upstart-exporter/options/global_spec.rb
+++ b/spec/lib/upstart-exporter/options/global_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../spec_helper'
+require File.expand_path('../../../spec_helper', File.dirname(__FILE__))
 
 describe Upstart::Exporter::Options::Global do
   let(:defaults){ Upstart::Exporter::Options::Global::DEFAULTS }

--- a/spec/lib/upstart-exporter/templates_spec.rb
+++ b/spec/lib/upstart-exporter/templates_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require File.expand_path('../../spec_helper', File.dirname(__FILE__))
 
 describe Upstart::Exporter::Templates do
   describe ".app" do

--- a/spec/lib/upstart-exporter/templates_spec.rb
+++ b/spec/lib/upstart-exporter/templates_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require_relative '../../spec_helper'
 
 describe Upstart::Exporter::Templates do
   describe ".app" do
@@ -55,6 +55,7 @@ stop on stopping SOMEAPP
 respawn
 respawn limit 5 10
 kill timeout 24
+kill signal SIGINT
 
 script
   touch /var/log/SOMEAPP/SOMECMD.log
@@ -65,16 +66,20 @@ script
 end script
 HEREDOC
 
-      expect(described_class.command(:run_user => 'SOMEUSER',
-                              :run_group => 'SOMEGROUP',
-                              :app_name => 'SOMEAPP',
-                              :cmd_name => 'SOMECMD',
-                              :respawn => 'respawn',
-                              :respawn_limit => 'respawn limit 5 10',
-                              :start_on => 'starting SOMEAPP',
-                              :stop_on => 'stopping SOMEAPP',
-                              :kill_timeout => 24,
-                              :helper_cmd_conf => 'HELPERPATH')).to eq(conf)
+      generated_file = described_class.command({
+        :run_user => 'SOMEUSER',
+        :run_group => 'SOMEGROUP',
+        :app_name => 'SOMEAPP',
+        :cmd_name => 'SOMECMD',
+        :respawn => 'respawn',
+        :respawn_limit => 'respawn limit 5 10',
+        :start_on => 'starting SOMEAPP',
+        :stop_on => 'stopping SOMEAPP',
+        :kill_timeout => 24,
+        :kill_signal => 'SIGINT',
+        :helper_cmd_conf => 'HELPERPATH'})
+
+      expect(generated_file).to eq(conf)
     end
   end
 

--- a/spec/lib/upstart-exporter_spec.rb
+++ b/spec/lib/upstart-exporter_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 describe Upstart::Exporter do
   let(:tpl){ Upstart::Exporter::Templates }

--- a/spec/lib/upstart-exporter_spec.rb
+++ b/spec/lib/upstart-exporter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require_relative '../spec_helper'
 
 describe Upstart::Exporter do
   let(:tpl){ Upstart::Exporter::Templates }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'fakefs/spec_helpers'
 
 require 'upstart-exporter'
 
-Dir['spec/support/**/*.rb'].each do |f|
+Dir["#{ File.dirname(__FILE__) }/support/**/*.rb"].each do |f|
   require f
 end
 


### PR DESCRIPTION
Add support of http://upstart.ubuntu.com/cookbook/#kill-signal
Fix to run tests for ruby > 1.9
