### PR TITLE
validate options in config and upstart file

### DIFF
--- a/lib/upstart-exporter/hash_utils.rb
+++ b/lib/upstart-exporter/hash_utils.rb
@@ -1,0 +1,22 @@
+module Upstart
+  class Exporter
+    class HashUtils
+
+      def self.symbolize_keys(obj)
+        case obj
+          when Hash
+            Hash[
+              obj.map do |key, value|
+                [key.respond_to?(:to_sym) ? key.to_sym : key, symbolize_keys(value)]
+              end
+            ]
+          when Array
+            obj.map {|value| symbolize_keys(value)}
+          else
+            obj
+        end
+      end
+
+    end
+  end
+end

--- a/lib/upstart-exporter/options/global.rb
+++ b/lib/upstart-exporter/options/global.rb
@@ -3,17 +3,17 @@ module Upstart::Exporter::Options
     include Upstart::Exporter::Errors
 
     DEFAULTS = {
-      'helper_dir' => '/var/local/upstart_helpers/',
-      'upstart_dir' => '/etc/init/',
-      'run_user' => 'service',
-      'run_group' => 'service',
-      'prefix' => 'fb-',
-      'start_on_runlevel' => '[3]',
-      'stop_on_runlevel' => '[3]',
-      'kill_timeout' => 30,
-      'respawn' => {
-        'count' => 5,
-        'interval' => 10
+      :helper_dir => '/var/local/upstart_helpers/',
+      :upstart_dir => '/etc/init/',
+      :run_user => 'service',
+      :run_group => 'service',
+      :prefix => 'fb-',
+      :start_on_runlevel => '[3]',
+      :stop_on_runlevel => '[3]',
+      :kill_timeout => 30,
+      :respawn => {
+        :count => 5,
+        :interval => 10
       }
     }
 
@@ -22,11 +22,12 @@ module Upstart::Exporter::Options
     def initialize
       super
       config = if FileTest.file?(CONF)
-        YAML::load(File.read(CONF))
+        Upstart::Exporter::HashUtils.symbolize_keys(YAML::load(File.read(CONF)))
       else
         $stderr.puts "#{CONF} not found"
         {}
       end
+
       error "#{CONF} is not a valid YAML config" unless config.is_a?(Hash)
       DEFAULTS.keys.each do |param|
         value = if config[param]

--- a/lib/upstart-exporter/options/validator.rb
+++ b/lib/upstart-exporter/options/validator.rb
@@ -1,0 +1,78 @@
+module Upstart::Exporter::Options
+  class Validator
+
+    include Upstart::Exporter::Errors
+
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+    end
+
+    def validate!
+      validate_path(options[:helper_dir])
+      validate_path(options[:upstart_dir])
+
+      reject_special_symbols(options[:run_user])
+      reject_special_symbols(options[:run_group])
+      reject_special_symbols(options[:prefix])
+
+      validate_runlevel(options[:start_on_runlevel])
+      validate_runlevel(options[:stop_on_runlevel])
+
+      validate_digits(options[:kill_timeout])
+
+      validate_respawn(options[:respawn])
+
+      if options[:procfile_commands][:version] == 2
+        validate_procfile_v2(options[:procfile_commands])
+      end
+    end
+
+    private
+
+      def validate_procfile_v2(config)
+        validate_command_params(config)
+        config[:commands].values.each {|cmd| validate_command_params(cmd)}
+      end
+
+      def validate_command_params(cmd)
+        validate_runlevel(cmd[:start_on_runlevel])
+        validate_runlevel(cmd[:stop_on_runlevel])
+        validate_path(cmd[:working_directory])
+        validate_respawn(cmd[:respawn])
+      end
+
+      def validate_respawn(options)
+        return unless options
+        validate_digits(options[:kill_timeout])
+        validate_digits(options[:interval])
+      end
+
+      def validate_path(val)
+        validate(val, /\A[A-Za-z0-9_\-.\/]+\z/)
+      end
+
+      def reject_special_symbols(val)
+        validate(val, /\A[A-Za-z0-9_\-]+\z/)
+      end
+
+      def validate_runlevel(val)
+        validate(val, /\A\[\d+\]\z/)
+      end
+
+      def validate_digits(val)
+        validate(val, /\A\d+\z/)
+      end
+
+      def validate(val, regexp)
+        val = val.to_s
+        return if val == ""
+
+        unless val =~ regexp
+          error("value #{val} is insecure and can't be accepted")
+        end
+      end
+
+  end
+end

--- a/lib/upstart-exporter/templates.rb
+++ b/lib/upstart-exporter/templates.rb
@@ -8,16 +8,10 @@ module Upstart
       end
 
       def self.app(binds)
-        if error_val = binds.find { |v| v =~ /\A[A-z0-9_\- ]*?\z/ }
-          error("value #{error_val} is insecure and can't be accepted")
-        end
         interpolate(APP_TPL, binds)
       end
 
       def self.command(binds)
-        if error_val = binds.find { |v| v =~ /\A[A-z0-9_\- ]*?\z/ }
-          error("value #{error_val} is insecure and can't be accepted")
-        end
         interpolate(COMMAND_TPL, binds)
       end
 

--- a/lib/upstart-exporter/version.rb
+++ b/lib/upstart-exporter/version.rb
@@ -1,5 +1,5 @@
 module Upstart
   class Exporter
-    VERSION = "2.1.2"
+    VERSION = "2.1.3"
   end
 end

--- a/spec/lib/upstart-exporter/expanded_exporter_spec.rb
+++ b/spec/lib/upstart-exporter/expanded_exporter_spec.rb
@@ -13,15 +13,15 @@ describe Upstart::Exporter::ExpandedExporter do
   it 'calls template render exact amount of times' do
     expect(Upstart::Exporter::Templates).to receive(:command).exactly(5).times
     options = {
-      :commands => {
-        'commands' => {
-          'ls' => {
-            'command' => 'ls',
-            'count' => 3
+      :procfile_commands => {
+        :commands => {
+          :ls => {
+            :command => 'ls',
+            :count => 3
           },
-          'ls2' => {
-            'command' => 'ls',
-            'count' => 2
+          :ls2 => {
+            :command => 'ls',
+            :count => 2
           }
         }
       },
@@ -37,16 +37,16 @@ describe Upstart::Exporter::ExpandedExporter do
       expect(options[:cmd]).to include('T=t')
     end
     options = {
-      :commands => {
-        'env' => {
-          'T' => 't',
-          'B' => 'a'
+      :procfile_commands => {
+        :env => {
+          :T => 't',
+          :B => 'a'
         },
-        'commands' => {
-          'ls' => {
-            'command' => 'ls',
-            'env' => {
-              'B' => 'b'
+        :commands => {
+          :ls => {
+            :command => 'ls',
+            :env => {
+              :B => 'b'
             }
           }
         }
@@ -63,37 +63,37 @@ describe Upstart::Exporter::ExpandedExporter do
       :app_name => 'appname',
       :working_directory => "/",
       :log => "public.log",
-      :commands => {
-        'working_directory' => '/var/log',
-        'commands' => {
-          'rm1' => {
-            'command' => 'rm *',
-            'log' => 'private.log'
+      :procfile_commands => {
+        :working_directory => '/var/log',
+        :commands => {
+          :rm1 => {
+            :command => 'rm *',
+            :log => 'private.log'
           },
-          'rm2' => {
-            'command' => 'rm -rf *',
-            'working_directory' => '/home'
+          :rm2 => {
+            :command => 'rm -rf *',
+            :working_directory => '/home'
           },
-          'rm3' => {
-            'command' => 'rm -f vmlinuz',
+          :rm3 => {
+            :command => 'rm -f vmlinuz',
           }
         }
       }
     }.merge(@defaults)
     expect(Upstart::Exporter::Templates).to receive(:helper).with(hash_including(
-      "working_directory"=>"/var/log",
-      "log"=>"private.log",
-      :cmd=>"cd '/var/log' && exec rm * >> private.log 2>&1"
+      :working_directory => "/var/log",
+      :log => "private.log",
+      :cmd=> "cd '/var/log' && exec rm * >> private.log 2>&1"
     ))
     expect(Upstart::Exporter::Templates).to receive(:helper).with(hash_including(
-      "working_directory"=>"/home",
-      "log"=>"public.log",
-      :cmd=>"cd '/home' && exec rm -rf * >> public.log 2>&1"
+      :working_directory =>"/home",
+      :log => "public.log",
+      :cmd => "cd '/home' && exec rm -rf * >> public.log 2>&1"
     ))
     expect(Upstart::Exporter::Templates).to receive(:helper).with(hash_including(
-      "working_directory"=>"/var/log",
-      "log"=>"public.log",
-      :cmd=>"cd '/var/log' && exec rm -f vmlinuz >> public.log 2>&1"
+      :working_directory =>"/var/log",
+      :log => "public.log",
+      :cmd => "cd '/var/log' && exec rm -f vmlinuz >> public.log 2>&1"
     ))
     described_class.export(options)
   end

--- a/spec/lib/upstart-exporter/options/command_line_spec.rb
+++ b/spec/lib/upstart-exporter/options/command_line_spec.rb
@@ -10,20 +10,20 @@ describe Upstart::Exporter::Options::CommandLine do
     it "should parse procfile" do
         make_procfile('Procfile', 'ls_cmd: ls')
         options = described_class.new(:app_name => 'someappname', :procfile => 'Procfile')
-        expect(options[:commands]).to eq({'ls_cmd' => ' ls'})
+        expect(options[:procfile_commands]).to eq({'ls_cmd' => ' ls'})
     end
 
     it 'should parse procfile v2' do
         make_procfile('Procfile', "version: 2\ncommands:\n  ls:\n    command: ls -al")
         options = described_class.new(:app_name => 'someappname', :procfile => 'Procfile')
-        expect(options[:commands]).to have_key('commands')
-        expect(options[:commands]['commands']).to have_key('ls')
+        expect(options[:procfile_commands]).to have_key(:commands)
+        expect(options[:procfile_commands][:commands]).to have_key(:ls)
     end
 
     it "should skip empty and commented lines in a procfile" do
         make_procfile('Procfile', "ls_cmd1: ls1\n\nls_cmd2: ls2\n # fooo baaar")
         options = described_class.new(:app_name => 'someappname', :procfile => 'Procfile')
-        expect(options[:commands]).to eq({'ls_cmd1' => ' ls1', 'ls_cmd2' => ' ls2'})
+        expect(options[:procfile_commands]).to eq({'ls_cmd1' => ' ls1', 'ls_cmd2' => ' ls2'})
     end
 
     it "should store app_name" do
@@ -36,7 +36,7 @@ describe Upstart::Exporter::Options::CommandLine do
         make_procfile('Procfile', "bad procfile")
         options = described_class.new(:app_name => 'someappname', :procfile => 'Procfile', :clear => true)
         expect(options[:app_name]).to eq('someappname')
-        expect(options[:commands]).to eq({})
+        expect(options[:procfile_commands]).to eq({})
     end
   end
 
@@ -65,7 +65,6 @@ describe Upstart::Exporter::Options::CommandLine do
       expect{ described_class.new(:app_name => 'someappname') }.to raise_exception
     end
   end
-
 
 end
 

--- a/spec/lib/upstart-exporter/options/global_spec.rb
+++ b/spec/lib/upstart-exporter/options/global_spec.rb
@@ -44,7 +44,7 @@ describe Upstart::Exporter::Options::Global do
     it "should preserve default values for options not specified in the config" do
       capture(:stderr) do
         make_global_config({'run_user' => 'wwwww'}.to_yaml)
-        described_class.new[:prefix] == defaults['prefix']
+        described_class.new[:prefix] == defaults[:prefix]
       end
     end
   end

--- a/spec/lib/upstart-exporter/options/validator_spec.rb
+++ b/spec/lib/upstart-exporter/options/validator_spec.rb
@@ -1,0 +1,42 @@
+require 'spec/spec_helper'
+
+describe Upstart::Exporter::Options::Validator do
+
+  it "validates paths" do
+    validator = described_class.new(:helper_dir => "/some/dir;")
+    expect {validator.validate!}.to raise_error(Upstart::Exporter::Error)
+  end
+
+  it "validates user names" do
+    validator = described_class.new(:run_user => "bad_user_name!")
+    expect {validator.validate!}.to raise_error(Upstart::Exporter::Error)
+  end
+
+  it "validates runlevels" do
+    validator = described_class.new(:start_on_runlevel => "[not_a_digit]")
+    expect {validator.validate!}.to raise_error(Upstart::Exporter::Error)
+  end
+
+  describe "procfile v2" do
+    it "validates respawn" do
+      options = {:procfile_commands => {:version => 2, :respawn => {:kill_timeout => "10;"}}}
+      validator = described_class.new(options)
+      expect {validator.validate!}.to raise_error(Upstart::Exporter::Error)
+    end
+
+    it "validates options for individual commands" do
+      options = {
+        :procfile_commands => {:version => 2,
+          :commands => {
+            :come_cmd => {
+              :working_directory => "!!!wrong_working-directory"
+            }
+          }
+        }
+      }
+      validator = described_class.new(options)
+      expect {validator.validate!}.to raise_error(Upstart::Exporter::Error)
+    end
+  end
+
+end


### PR DESCRIPTION
validate options in config and upstart file
code refactored to use symbols as hash keys instead of mixture of both symbols and strings in one hash